### PR TITLE
Add requests library requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pysha3
+requests
+


### PR DESCRIPTION
The JSON RPC backend requires the requests library to operate, figured I would add it to the requirements file. There is no version pinned for the previous lib, so I did the same here. 