### PR TITLE
Read the README.rst with UTF8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version = version,
     description = 'A comprehensive Python module for handling Monero cryptocurrency',
     url = 'https://github.com/emesik/monero-python/',
-    long_description = open('README.rst').read(),
+    long_description = open('README.rst', encoding = 'utf8').read(),
     install_requires = open('requirements.txt', 'r').read().splitlines(),
     packages = find_packages('.', exclude=['tests']),
     include_package_data = True,


### PR DESCRIPTION
This change resolves the following decode issue on Windows CMD which uses CP950 by default.
```
C:\Users\Lafudoci>pip install monero-python
Collecting monero-python
  Using cached https://files.pythonhosted.org/packages/c6/71/71c89009a74a6ced66046fd65e668991b6e0cbf
fe41b16150dd102c7e5e3/monero-python-0.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\LeftC\AppData\Local\Temp\pip-install-a452m9hl\monero-python\setup.py", line 12,
 in <module>
        long_description = open('README.rst').read(),
    UnicodeDecodeError: 'cp950' codec can't decode byte 0xc5 in position 621: illegal multibyte sequ
ence
```