### PR TITLE
use stable python 3.7 in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ dist: xenial # minimal version required for python 3.7 support
 python:
   - "2.7"
   - "3.6"
-  - "3.7-dev"  # until 3.7 is officially supported by travis this is only (simple) way to test it
-  - "nightly"
-
 matrix:
+  include:
+    - python: 3.7 # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+      sudo: true
   allow_failures:
     python: "nightly"
 


### PR DESCRIPTION
Travis so has some issues with running python 3.7 natively, and due to that initially the old, no longer updated, "-dev" version was used. This PR fixes that by using a stable release - much more likely used by the end users of the package.

Related travis issue: https://github.com/travis-ci/travis-ci/issues/9815