### PR TITLE
Sidebar "menu" on documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,9 +102,13 @@ html_static_path = ['_static']
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
-    '**': [
+    'index': [
         'relations.html',  # needs 'show_related': True theme option to display
+        'searchbox.html'
+    ],
+    '**': [
         'searchbox.html',
+        'globaltoc.html'
     ]
 }
 
@@ -164,6 +168,3 @@ texinfo_documents = [
      author, 'MoneroPythonmodule', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-


### PR DESCRIPTION
 As it is currently we have to navigate back to the `index` in order to access the rest of the contents of the documentation. So this pull request adds the table of contents to the sidebar (except on the index page), to make it easier to explore and navigate through the docs..