### PR TITLE
Caching of ed25519 values for public keys in seed

### DIFF
--- a/monero/seed.py
+++ b/monero/seed.py
@@ -61,6 +61,9 @@ class Seed(object):
 
         self.word_list = wordlists.get_wordlist(wordlist)
 
+        self._ed_pub_spend_key = None
+        self._ed_pub_view_key = None
+
         if phrase_or_hex:
             seed_split = phrase_or_hex.split(" ")
             if len(seed_split) >= 24:
@@ -137,10 +140,16 @@ class Seed(object):
         return self.sc_reduce(h.digest())
 
     def public_spend_key(self):
-        return ed25519.public_from_secret_hex(self.secret_spend_key())
+        if self._ed_pub_spend_key:
+            return self._ed_pub_spend_key
+        self._ed_pub_spend_key = ed25519.public_from_secret_hex(self.secret_spend_key())
+        return self._ed_pub_spend_key
 
     def public_view_key(self):
-        return ed25519.public_from_secret_hex(self.secret_view_key())
+        if self._ed_pub_view_key:
+            return self._ed_pub_view_key
+        self._ed_pub_view_key = ed25519.public_from_secret_hex(self.secret_view_key())
+        return self._ed_pub_view_key
 
     def public_address(self, net='mainnet'):
         """Returns the master :class:`Address <monero.address.Address>` represented by the seed.


### PR DESCRIPTION
Based on:

https://github.com/emesik/monero-python/issues/42#issuecomment-458780087

All tests pass:

```
========================================= test session starts ==========================================
platform linux -- Python 3.7.2, pytest-3.10.1, py-1.7.0, pluggy-0.8.1
rootdir: /home/mwo2/monero-python, inifile: setup.cfg
plugins: cov-2.6.1
collected 74 items                                                                                     

tests/test_address.py ............................                                               [ 37%]
tests/test_base58.py ....                                                                        [ 43%]
tests/test_ed25519.py .                                                                          [ 44%]
tests/test_jsonrpcwallet.py ..............                                                       [ 63%]
tests/test_numbers.py ...                                                                        [ 67%]
tests/test_offline.py ....                                                                       [ 72%]
tests/test_seed.py .............                                                                 [ 90%]
tests/test_transaction.py ..                                                                     [ 93%]
tests/test_wallet.py .....                                                                       [100%]

----------- coverage: platform linux, python 3.7.2-final-0 -----------
Name                                     Stmts   Miss  Cover
------------------------------------------------------------
monero/__init__.py                           2      0   100%
monero/account.py                           24      2    92%
monero/address.py                           89      1    99%
monero/backends/__init__.py                  0      0   100%
monero/backends/jsonrpc.py                 209     69    67%
monero/backends/offline.py                  48     14    71%
monero/base58.py                            95      7    93%
monero/daemon.py                            11      5    55%
monero/ed25519.py                           85      0   100%
monero/exceptions.py                        30      2    93%
monero/numbers.py                           37      1    97%
monero/prio.py                               4      0   100%
monero/seed.py                              85      3    96%
monero/transaction.py                      136     10    93%
monero/wallet.py                            91     12    87%
monero/wordlists/__init__.py                13      0   100%
monero/wordlists/chinese_simplified.py       6      0   100%
monero/wordlists/dutch.py                    6      0   100%
monero/wordlists/english.py                  6      0   100%
monero/wordlists/esperanto.py                6      0   100%
monero/wordlists/french.py                   6      0   100%
monero/wordlists/german.py                   6      0   100%
monero/wordlists/italian.py                  6      0   100%
monero/wordlists/japanese.py                 6      0   100%
monero/wordlists/lojban.py                   6      0   100%
monero/wordlists/portuguese.py               6      0   100%
monero/wordlists/russian.py                  6      0   100%
monero/wordlists/spanish.py                  6      0   100%
monero/wordlists/wordlist.py                69      9    87%
------------------------------------------------------------
TOTAL                                     1100    135    88%


===================================== 74 passed in 220.08 seconds ======================================
```